### PR TITLE
Add csv response type

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -1,0 +1,16 @@
+package response
+
+import (
+	"encoding/csv"
+	"net/http"
+)
+
+// CSV writes v as a CSV file to the ResponseWriter.``
+func CSV(v [][]string, w http.ResponseWriter, status int) (err error) {
+	w.Header().Set("Content-Type", "text/csv")
+	w.WriteHeader(status)
+	csvw := csv.NewWriter(w)
+	csvw.WriteAll(v)
+	csvw.Flush()
+	return
+}

--- a/csv.go
+++ b/csv.go
@@ -10,7 +10,10 @@ func CSV(v [][]string, w http.ResponseWriter, status int) (err error) {
 	w.Header().Set("Content-Type", "text/csv")
 	w.WriteHeader(status)
 	csvw := csv.NewWriter(w)
-	csvw.WriteAll(v)
+	err = csvw.WriteAll(v)
+	if err != nil {
+		return
+	}
 	csvw.Flush()
 	return
 }


### PR DESCRIPTION
Accepts a 2D array of strings. Sends a `text/csv` response using go's in-built csv library.